### PR TITLE
Add devops team as top-level dir file codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
-*   @calidae/bruixes
+*              @calidae/bruixes
+/*             @calidae/bruixes @calidae/devops
+.github/**     @calidae/bruixes @calidae/devops


### PR DESCRIPTION
All files in the top-level directory should be watched by this
team, as well as any file under the .github directory.