### PR TITLE
Use PyPA build instead of pip wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: Install wheel
+    - name: Install PyPA build
       run: |
-        python3 -m pip install --upgrade pip wheel
+        python3 -m pip install build
 
-    - name: Prepare wheel distribution
-      run: pip wheel --no-deps --wheel-dir=dist .
+    - name: Prepare distribution
+      run: python -m build .
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This will craft both a wheel and a source distribution
and as a dedicated PEP-517 building frontend it requires
less boilerplate CLI options.