### PR TITLE
Use TOX_SKIP_ENV for smarter CI jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,6 @@ jobs:
     strategy:
       matrix:
         py: ["3.8", "3.9", "3.10"]
-        pytest: ["5", "6", "7"]
-        exclude:
-          - py: "3.10"
-            pytest: "5"
 
     steps:
     - uses: actions/checkout@v2
@@ -31,8 +27,10 @@ jobs:
       run: |
         pip install tox
     - name: Run test environments
+      env:
+        TOX_SKIP_ENV: "^((?!py${{ matrix.py }}).)*$"
       run: |
-        tox -e py${{ matrix.py }}-pytest${{ matrix.pytest }}-trytond50,py${{ matrix.py }}-pytest${{ matrix.pytest }}-trytond60,py${{ matrix.py }}-pytest${{ matrix.pytest }}-trytonddev
+        tox
 
   lint:
 


### PR DESCRIPTION
Use a negative lookup regeix in the TOX_SKIP_ENV variable
to skip all tox testenvs that won't match the python version
that is set up for each CI job.

This should increase test efficiency, since trytond database
caches can be reused across testenvs, and also simplifies
the CI job script readability keeping it agnostic of the
underlying tox dependency matrix.

See https://stackoverflow.com/a/70955892/11715259
